### PR TITLE
judge item if it is in keys

### DIFF
--- a/algorithm/Tree.py
+++ b/algorithm/Tree.py
@@ -85,6 +85,8 @@ class Tree:
                 for item, count in collections.Counter(
                     [str(t) for t in executions_list]
                 ).items():
+                    if item not in executions.keys():
+                        continue
                     executions[item] += count * val
 
         self.replay_fitness = matches / denominator


### PR DESCRIPTION
algorithm/Tree.py count_replay_fitness_and_generalization()，
for item, count in collections.Counter(
[str(t) for t in executions_list]
).items(): 
It maybe item not in keys，so it is needed to judge。
My suggestions as follows：
if item not in executions.keys():
continue